### PR TITLE
Using the right scheme for resources

### DIFF
--- a/app/themes/default/templates/layout.html
+++ b/app/themes/default/templates/layout.html
@@ -8,7 +8,7 @@
 <html class="no-js" lang="en-US">
     <head>
         <meta charset="utf-8">
-        <base href="<%= config.base %>>"
+        <base href="<%= config.base %>">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title><%= title ? title+" | " : ""%> <%= config.site_title %></title>
         <link rel="stylesheet" href="styles/tidy.css" type='text/css' media='all' />

--- a/app/themes/default/templates/layout.html
+++ b/app/themes/default/templates/layout.html
@@ -8,12 +8,12 @@
 <html class="no-js" lang="en-US">
     <head>
         <meta charset="utf-8">
-        <base href="<%= config.base %>">
+        <base href="<%= config.base %>>"
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title><%= title ? title+" | " : ""%> <%= config.site_title %></title>
         <link rel="stylesheet" href="styles/tidy.css" type='text/css' media='all' />
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
-        <link rel='stylesheet' href='http://fonts.googleapis.com/css?family=Muli%3A400%2C300&#038;subset=latin&#038;ver=4.4.2' type='text/css' media='all' />
+        <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+        <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Muli%3A400%2C300&#038;subset=latin&#038;ver=4.4.2" type="text/css" media="all" />
         <%- style %>
         <meta name="viewport" content="width=device-width, initial-scale=1">
     </head>


### PR DESCRIPTION
Not hard-coding the scheme for resources, so that `https` Hazel instances work without browsers complaining.
